### PR TITLE
Deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__
 venv/
+dist/
 
 # IDE
 .vscode/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+ install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,9 @@
+sphinx
+sphinx-rtd-theme
+gymnasium
+minigrid
+numpy
+plotly
+pytimedinput
+PyYAML
+torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "gymnasium ~=0.29.1",
-    "kaleido ~=0.2.1",
-    "numpy ~=1.25.2",
-    "plotly ~=5.18.0",
-    "pytimedinput ~=2.0.1",
-    "PyYAML ~=6.0.1",
-    "torch ~=2.1.0",
+    "gymnasium ~=0.29",
+    "kaleido ~=0.2",
+    "numpy ~=1.25",
+    "plotly ~=5.18",
+    "pytimedinput ~=2.0",
+    "PyYAML ~=6.0",
+    "torch ~=2.1",
 ]
 keywords = [
     "curriculum-learning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 dependencies = [
     "gymnasium ~=0.29.1",
     "kaleido ~=0.2.1",
-    "minigrid ~=2.3.1",
     "numpy ~=1.25.2",
     "plotly ~=5.18.0",
     "pytimedinput ~=2.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["./academia"]
+
+[tool.hatch.build.targets.sdist]
+packages = ["./academia"]
+
+[project]
+name = "academia"
+version = "0.1.0"
+authors = [
+    { name="krezelj", email="jasiekk9@gmail.com" },
+    { name="guts", email="szymon.gut01@gmail.com" },
+    { name="maciejors", email="maciej.orslowski@gmail.con" },
+]
+description = "Easy-to-use tools for Curriculum Learning"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "gymnasium ~=0.29.1",
+    "kaleido ~=0.2.1",
+    "minigrid ~=2.3.1",
+    "numpy ~=1.25.2",
+    "plotly ~=5.18.0",
+    "pytimedinput ~=2.0.1",
+    "PyYAML ~=6.0.1",
+    "torch ~=2.1.0",
+]
+keywords = [
+    "curriculum-learning",
+    "reinforcement-learning",
+]
+
+[project.urls]
+"Source code" = "https://github.com/krezelj/wut-curriculum-learning"
+Documentation = "https://github.com/krezelj/wut-curriculum-learning"  # TODO: temporary url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy~=1.25.2
-gymnasium~=0.29.1
-torch~=2.1.0
-PyYAML~=6.0.1


### PR DESCRIPTION
First of all, this PR closes #205 (original `requirements.txt` has been simplified, moved to `docs/` and repurposed)

Secondly, it does **not** cIose #6 but does some huge steps towards that by:
- adding package deployment configuration (`pyproject.toml`),
- adding Read the Docs deployment configuration (`.readthedocs.yaml`).

Issues I believe should be resolved before the initial beta release:
- #129,
- #176,
- #190 !!!